### PR TITLE
add per-board power management

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -9,8 +9,15 @@ include $(CLEAR_VARS)
 LOCAL_PRELINK_MODULE := false
 LOCAL_MODULE_PATH := $(TARGET_OUT_SHARED_LIBRARIES)/hw
 LOCAL_SHARED_LIBRARIES := liblog libcutils
-LOCAL_MODULE := gps.default
+LOCAL_MODULE := gps.$(TARGET_PRODUCT)
 LOCAL_MODULE_TAGS := optional
 LOCAL_SRC_FILES := gps.c
+
+ifeq ($(wildcard $(LOCAL_PATH)/power-$(TARGET_PRODUCT).c),)
+LOCAL_SRC_FILES += power-stub.c
+else
+LOCAL_SRC_FILES += power-$(TARGET_PRODUCT).c
+endif
+
 include $(BUILD_SHARED_LIBRARY)
 endif

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ ie. ro.kernel.android.gps=ttyO1
 Default baud rate is 9600, to adjust add a property "ro.kernel.android.gpsttybaud" and set it equal to the needed rate. (4800-115200)
 ie. ro.kernel.android.gpsttybaud=9600
 
+To add power management for your target product, `cp power-stubs.c power-$(TARGET_PRODUCT).c` and fill in the stubs.
+
 Notes:
 * If using a USB device make sure you have the necessary kernel modules loaded or built in to the kernel.
 * Make sure the permissions on your device file are correct

--- a/gps.c
+++ b/gps.c
@@ -60,8 +60,8 @@ static int    id_in_fixed[12];
 #define GPS_DEV_SLOW_UPDATE_RATE (10)
 #define GPS_DEV_HIGH_UPDATE_RATE (1)
 
-static void gps_dev_init(int fd);
-static void gps_dev_deinit(int fd);
+extern bool gps_power_on();
+extern bool gps_power_off();
 static void gps_dev_start(int fd);
 static void gps_dev_stop(int fd);
 
@@ -779,6 +779,8 @@ gps_state_start( GpsState*  s )
     char  cmd = CMD_START;
     int   ret;
 
+    gps_power_on();
+
     do {
         ret = write( s->control[0], &cmd, 1 );
     } while (ret < 0 && errno == EINTR);
@@ -801,6 +803,8 @@ gps_state_stop( GpsState*  s )
     if (ret != 1)
         D("%s: could not send CMD_STOP command: ret=%d: %s",
           __FUNCTION__, ret, strerror(errno));
+
+    gps_power_off();
 }
 
 
@@ -1154,12 +1158,6 @@ const GpsInterface* gps_get_hardware_interface()
 /*****************************************************************/
 /*****************************************************************/
 
-static void gps_dev_power(int state)
-{
-    return;
-}
-
-
 static void gps_dev_send(int fd, char *msg)
 {
     int i, n, ret;
@@ -1249,21 +1247,6 @@ static void gps_dev_set_message_rate(int fd, int rate)
 
     return;
 }
-
-
-static void gps_dev_init(int fd)
-{
-    gps_dev_power(1);
-
-    return;
-}
-
-
-static void gps_dev_deinit(int fd)
-{
-    gps_dev_power(0);
-}
-
 
 static void gps_dev_start(int fd)
 {

--- a/power-stub.c
+++ b/power-stub.c
@@ -1,0 +1,9 @@
+int gps_power_on()
+{
+    return 0;
+}
+
+int gps_power_off()
+{
+    return 0;
+}


### PR DESCRIPTION
Adding per-board power management support enables multiple devices to be built and used with the same AOSP repo manifest.